### PR TITLE
[stable/jenkins] Double retry count for Jenkins test

### DIFF
--- a/stable/jenkins/templates/test-config.yaml
+++ b/stable/jenkins/templates/test-config.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   run.sh: |-
     @test "Testing Jenkins UI is accessible" {
-      curl --retry 12 --retry-delay 10 {{.Release.Name}}-jenkins:8080/login
+      curl --retry 24 --retry-delay 10 {{.Release.Name}}-jenkins:8080/login
     }


### PR DESCRIPTION
The Jenkins test fail intermittently in e2e testing. This should provide enough time for Jenkins to come up before the test errors out.

cc @cblecker @mattfarina