### PR TITLE
Scope helper names, add resource label helpers

### DIFF
--- a/stable/spinnaker/templates/_helpers.tpl
+++ b/stable/spinnaker/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "spinnaker.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "spinnaker.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/spinnaker/templates/_helpers.tpl
+++ b/stable/spinnaker/templates/_helpers.tpl
@@ -14,3 +14,21 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels for metadata.
+*/}}
+{{- define "spinnaker.standard-labels" -}}
+app: {{ include "spinnaker.fullname" . | quote }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- end -}}
+
+{{/*
+A set of common selector labels for resources.
+*/}}
+{{- define "spinnaker.standard-selector-labels" -}}
+app: {{ include "spinnaker.fullname" . | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "spinnaker.fullname" . }}-halyard-config
   labels:
-    app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 4 }}
 data:
   install.sh: |
     # Wait for the Hal daemon to be ready

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-halyard-config
+  name: {{ template "spinnaker.fullname" . }}-halyard-config
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "spinnaker.fullname" . }}
 data:
   install.sh: |
     # Wait for the Hal daemon to be ready
-    export DAEMON_ENDPOINT=http://{{ template "fullname" . }}-halyard:8064
+    export DAEMON_ENDPOINT=http://{{ template "spinnaker.fullname" . }}-halyard:8064
     export HAL_COMMAND="hal --daemon-endpoint $DAEMON_ENDPOINT"
     until $HAL_COMMAND --ready; do sleep 10 ; done
 
@@ -19,7 +19,7 @@ data:
 
     $HAL_COMMAND deploy apply
   clean.sh: |
-    export HAL_COMMAND='hal --daemon-endpoint http://{{ template "fullname" . }}-halyard:8064'
+    export HAL_COMMAND='hal --daemon-endpoint http://{{ template "spinnaker.fullname" . }}-halyard:8064'
     $HAL_COMMAND deploy clean -q
   config.sh: |
     # Spinnaker version

--- a/stable/spinnaker/templates/hooks/cleanup.yaml
+++ b/stable/spinnaker/templates/hooks/cleanup.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-cleanup-using-hal"
+  name: "{{ template "spinnaker.fullname" . }}-cleanup-using-hal"
   labels:
-    app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 4 }}
     component: halyard
   annotations:
     "helm.sh/hook": "pre-delete"
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 8 }}
         component: halyard
     spec:
       restartPolicy: OnFailure

--- a/stable/spinnaker/templates/hooks/cleanup.yaml
+++ b/stable/spinnaker/templates/hooks/cleanup.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-cleanup-using-hal"
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "spinnaker.fullname" . }}
     component: halyard
   annotations:
     "helm.sh/hook": "pre-delete"
@@ -12,14 +12,14 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "spinnaker.fullname" . }}
         component: halyard
     spec:
       restartPolicy: OnFailure
       volumes:
       - name: halyard-config
         configMap:
-          name: {{ template "fullname" . }}-halyard-config
+          name: {{ template "spinnaker.fullname" . }}-halyard-config
       containers:
       - name: halyard-install
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-install-using-hal"
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "spinnaker.fullname" . }}
     component: halyard
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "spinnaker.fullname" . }}
         component: halyard
     spec:
       {{- if .Values.nodeSelector }}
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       - name: halyard-config
         configMap:
-          name: {{ template "fullname" . }}-halyard-config
+          name: {{ template "spinnaker.fullname" . }}-halyard-config
       {{- if .Values.halyard.additionalConfig.enabled }}
       - name: additional-config
         configMap:

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-install-using-hal"
   labels:
-    app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 4 }}
     component: halyard
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 8 }}
         component: halyard
     spec:
       {{- if .Values.nodeSelector }}

--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
 {{ toYaml .Values.deck.ingress.annotations | indent 4 }}
 {{- end }}
-  name: {{ template "fullname" . }}
+  name: {{ template "spinnaker.fullname" . }}
 spec:
   rules:
   - host: {{ .Values.deck.host | quote }}
@@ -14,7 +14,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ template "fullname" . }}-deck
+          serviceName: {{ template "spinnaker.fullname" . }}-deck
           servicePort: {{ .Values.deck.port }}
 {{- if .Values.deck.ingress.tls }}
   tls:

--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -7,6 +7,8 @@ metadata:
 {{ toYaml .Values.deck.ingress.annotations | indent 4 }}
 {{- end }}
   name: {{ template "spinnaker.fullname" . }}
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
 spec:
   rules:
   - host: {{ .Values.deck.host | quote }}

--- a/stable/spinnaker/templates/rbac/halyard-sa.yaml
+++ b/stable/spinnaker/templates/rbac/halyard-sa.yaml
@@ -10,10 +10,10 @@ roleRef:
 subjects:
 - namespace: {{ .Release.Namespace }}
   kind: ServiceAccount
-  name: {{ template "fullname" . }}-halyard
+  name: {{ template "spinnaker.fullname" . }}-halyard
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
- name: {{ template "fullname" . }}-halyard
+ name: {{ template "spinnaker.fullname" . }}-halyard
  namespace: {{ .Release.Namespace }}

--- a/stable/spinnaker/templates/rbac/halyard-sa.yaml
+++ b/stable/spinnaker/templates/rbac/halyard-sa.yaml
@@ -2,11 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
- name: {{ .Release.Name }}-halyard
+  name: {{ .Release.Name }}-halyard
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
 roleRef:
- apiGroup: rbac.authorization.k8s.io
- kind: ClusterRole
- name: edit
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
 subjects:
 - namespace: {{ .Release.Namespace }}
   kind: ServiceAccount
@@ -15,5 +17,7 @@ subjects:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
- name: {{ template "spinnaker.fullname" . }}-halyard
- namespace: {{ .Release.Namespace }}
+  name: {{ template "spinnaker.fullname" . }}-halyard
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}

--- a/stable/spinnaker/templates/rbac/spinnaker-sa.yaml
+++ b/stable/spinnaker/templates/rbac/spinnaker-sa.yaml
@@ -2,13 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
- name: {{ .Release.Name }}-spinnaker
+  name: {{ .Release.Name }}-spinnaker
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
 roleRef:
- apiGroup: rbac.authorization.k8s.io
- kind: ClusterRole
- name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
 subjects:
 - namespace: {{ .Release.Namespace }}
   kind: ServiceAccount
   name: default
-{{ end }}
+{{- end }}

--- a/stable/spinnaker/templates/secrets/gcs.yaml
+++ b/stable/spinnaker/templates/secrets/gcs.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "spinnaker.fullname" . }}-gcs
   labels:
-    app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 4 }}
     component: halyard
 type: Opaque
 data:

--- a/stable/spinnaker/templates/secrets/gcs.yaml
+++ b/stable/spinnaker/templates/secrets/gcs.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}-gcs
+  name: {{ template "spinnaker.fullname" . }}-gcs
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "spinnaker.fullname" . }}
     component: halyard
 type: Opaque
 data:

--- a/stable/spinnaker/templates/secrets/registry.yaml
+++ b/stable/spinnaker/templates/secrets/registry.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ template "spinnaker.fullname" . }}-registry
   labels:
-    app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 4 }}
     component: clouddriver
 type: Opaque
 data:

--- a/stable/spinnaker/templates/secrets/registry.yaml
+++ b/stable/spinnaker/templates/secrets/registry.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}-registry
+  name: {{ template "spinnaker.fullname" . }}-registry
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "spinnaker.fullname" . }}
     component: clouddriver
 type: Opaque
 data:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "spinnaker.fullname" . }}-halyard
   labels:
-    app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 4 }}
     component: halyard
 spec:
   ports:
@@ -18,17 +18,19 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "spinnaker.fullname" . }}-halyard
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
 spec:
   serviceName: {{ template "spinnaker.fullname" . }}-halyard
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-selector-labels" . | indent 6 }}
       component: halyard
   template:
     metadata:
       labels:
-        app: {{ template "spinnaker.fullname" . }}
+{{ include "spinnaker.standard-labels" . | indent 8 }}
         component: halyard
     spec:
       serviceAccountName: {{ template "spinnaker.fullname" . }}-halyard
@@ -90,6 +92,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: halyard-home
+      labels:
+{{ include "spinnaker.standard-labels" . | indent 8 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-halyard
+  name: {{ template "spinnaker.fullname" . }}-halyard
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "spinnaker.fullname" . }}
     component: halyard
 spec:
   ports:
@@ -11,27 +11,27 @@ spec:
     name: daemon
   clusterIP: None
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "spinnaker.fullname" . }}
     component: halyard
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "fullname" . }}-halyard
+  name: {{ template "spinnaker.fullname" . }}-halyard
 spec:
-  serviceName: {{ template "fullname" . }}-halyard
+  serviceName: {{ template "spinnaker.fullname" . }}-halyard
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "spinnaker.fullname" . }}
       component: halyard
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "spinnaker.fullname" . }}
         component: halyard
     spec:
-      serviceAccountName: {{ template "fullname" . }}-halyard
+      serviceAccountName: {{ template "spinnaker.fullname" . }}-halyard
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
@@ -64,7 +64,7 @@ spec:
       {{- if .Values.gcs.enabled }}
       - name: gcs-key
         secret:
-          secretName: {{ template "fullname" . }}-gcs
+          secretName: {{ template "spinnaker.fullname" . }}-gcs
       {{- end }}
       - name: halyard-config
         emptyDir: {}


### PR DESCRIPTION
We've run into issues with unscoped helper names + chart dependencies. Also adds consistent labels for resources.

These patches should have applied cleanly but keep an eye out for issues.