### PR TITLE
Fix deck service name

### DIFF
--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -14,7 +14,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ template "fullname" . }}-deck
+          serviceName: spin-deck
           servicePort: {{ .Values.deck.port }}
 {{- if .Values.deck.ingress.tls }}
   tls:


### PR DESCRIPTION
Services created by halyard have a predefined name:

https://github.com/spinnaker/halyard/blob/master/halyard-deploy/src/main/resources/kubernetes/manifests/service.yml

For deck, it's always 'spin-deck'.