### PR TITLE
Moving 'hosts' to ingress

### DIFF
--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -11,7 +11,7 @@ metadata:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
 spec:
   rules:
-  - host: {{ .Values.host | quote }}
+  - host: {{ .Values.ingress.host | quote }}
     http:
       paths:
       - path: /


### PR DESCRIPTION
# Description

Changes the the `host` to be under the `ingress` resource.

# Motivation and Context
Most Helm charts follow this convention. For example, the Grafana Helm chart: https://github.com/helm/charts/blob/master/stable/grafana/templates/ingress.yaml