### PR TITLE
Stable jenkins add multiple ingress hosts

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.7.0
-appVersion: 0.5.0
+version: 0.7.1
+appVersion: 0.5.4
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
 - https://github.com/kubernetes-incubator/external-dns

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
       - ingresses
       - services
       - pods
+      - nodes
     verbs:
       - get
       - list

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -1,7 +1,7 @@
 ## Details about the image to be pulled.
 image:
   name: registry.opensource.zalan.do/teapot/external-dns
-  tag: v0.5.0
+  tag: v0.5.4
   pullSecrets: []
   pullPolicy: IfNotPresent
 

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.11
+version: 0.16.12
 appVersion: 2.121.1
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.13
-appVersion: 2.121.1
+version: 0.16.14
+appVersion: 2.121.2
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
   projects as well as arbitrary scripts.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.12
+version: 0.16.13
 appVersion: 2.121.1
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.14
+version: 0.16.15
 appVersion: 2.121.2
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.15
+version: 0.16.16
 appVersion: 2.121.2
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.9
+version: 0.16.11
 appVersion: 2.121.1
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.16
+version: 1.0.0
 appVersion: 2.121.2
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -52,7 +52,6 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.HealthProbesLivenessTimeout`      | Set the timeout for the liveness probe | `120`                                                       |
 | `Master.HealthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                                                       |
 | `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
-| `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
 | `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                                      |
 | `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                      |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -38,6 +38,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
 | `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
 | `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
+| `Master.JenkinsAdminEmail`        | Email address for the administrator of the Jenkins instance | Not set                                               |
 | `Master.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 2048Mi}}`|
 | `Master.InitContainerEnv`         | Environment variables for Init Container                                 | Not set                                  |
 | `Master.ContainerEnv`             | Environment variables for Jenkins Container                              | Not set                                  |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -54,15 +54,19 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.HealthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                                                       |
 | `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
-| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                                      |
-| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                      |
-| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatibility | `true`                                                                      |
+| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                 |
+| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                |
+| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatibility | `true`                                                               |
 | `Master.CLI`                      | Enable CLI over remoting             | `false`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
 | `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
 | `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
 | `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
+| `Master.Ingress.Enabled`          | Use an Ingress                       | `false`                                                                      |
+| `Master.Ingress.ApiVersion`       | Ingress API version                  | `extensions/v1beta1`                                                         |
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
+| `Master.Ingress.Path`             | Ingress path                         | `/`                                                                          |
+| `Master.Ingress.Hosts`            | Ingress record(s)                    | Not set                                                                      |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -24,6 +24,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jenkins.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "jenkins.kubernetes-version" -}}
   {{- range .Values.Master.InstallPlugins -}}
     {{ if hasPrefix "kubernetes:" . }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -155,6 +155,20 @@ data:
       <pendingClasspathEntries/>
     </scriptApproval>
 {{- end }}
+  jenkins.model.JenkinsLocationConfiguration.xml: |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <jenkins.model.JenkinsLocationConfiguration>
+      <adminAddress>{{ default "" .Values.Master.JenkinsAdminEmail }}</adminAddress>
+{{- if .Values.Master.HostName }}
+{{- if .Values.Master.Ingress.TLS }}
+      <jenkinsUrl>https://{{ .Values.Master.HostName }}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+{{- else }}
+      <jenkinsUrl>http://{{ .Values.Master.HostName }}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+{{- end }}
+{{- else }}
+      <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+{{- end}}
+    </jenkins.model.JenkinsLocationConfiguration>
   jenkins.CLI.xml: |-
     <?xml version='1.1' encoding='UTF-8'?>
     <jenkins.CLI>
@@ -169,6 +183,7 @@ data:
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
     cp -n /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
+    cp -n /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml /var/jenkins_home;
 {{- if .Values.Master.InstallPlugins }}
     # Install missing plugins
     cp /var/jenkins_config/plugins.txt /var/jenkins_home;

--- a/stable/jenkins/templates/jenkins-agent-svc.yaml
+++ b/stable/jenkins/templates/jenkins-agent-svc.yaml
@@ -14,6 +14,9 @@ spec:
   ports:
     - port: {{ .Values.Master.SlaveListenerPort }}
       targetPort: {{ .Values.Master.SlaveListenerPort }}
+      {{ if (and (eq .Values.Master.SlaveListenerServiceType "NodePort") (not (empty .Values.Master.SlaveListenerPort))) }}
+      nodePort: {{.Values.Master.SlaveListenerPort}}
+      {{end}}
       name: slavelistener
   selector:
     component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -59,6 +59,8 @@ spec:
           env:
 {{ toYaml .Values.Master.InitContainerEnv | indent 12 }}
           {{- end }}
+          resources:
+{{ toYaml .Values.Master.resources | indent 12 }}
           volumeMounts:
             -
               mountPath: /var/jenkins_home

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -102,7 +102,7 @@ spec:
           args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]
           {{- end }}
           env:
-            - name: JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
               value: "{{ default "" .Values.Master.JavaOpts}}"
             - name: JENKINS_OPTS
               value: "{{ if .Values.Master.JenkinsUriPrefix }}--prefix={{ .Values.Master.JenkinsUriPrefix }} {{ end }}{{ default "" .Values.Master.JenkinsOpts}}"

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -120,7 +120,7 @@ spec:
 {{ toYaml .Values.Master.ContainerEnv | indent 12 }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.Master.ContainerPort }}
+            - containerPort: 8080
               name: http
             - containerPort: {{ .Values.Master.SlaveListenerPort }}
               name: slavelistener

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -1,22 +1,39 @@
-{{- if .Values.Master.HostName }}
+{{- if .Values.Master.Ingress.Enabled -}}
+{{- $fullName := include "jenkins.fullname" . -}}
+{{- $servicePort := .Values.Master.ServicePort -}}
+{{- $ingressPath := .Values.Master.Ingress.Path -}}
 apiVersion: {{ .Values.Master.Ingress.ApiVersion }}
 kind: Ingress
 metadata:
-{{- if .Values.Master.Ingress.Annotations }}
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "jenkins.name" . }}
+    chart: {{ template "jenkins.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.Master.Ingress.Annotations }}
   annotations:
-{{ toYaml .Values.Master.Ingress.Annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
-  name: {{ template "jenkins.fullname" . }}
 spec:
-  rules:
-  - host: {{ .Values.Master.HostName | quote }}
-    http:
-      paths:
-      - backend:
-          serviceName: {{ template "jenkins.fullname" . }}
-          servicePort: {{ .Values.Master.ServicePort }}
 {{- if .Values.Master.Ingress.TLS }}
   tls:
-{{ toYaml .Values.Master.Ingress.TLS | indent 4 }}
-{{- end -}}
+  {{- range .Values.Master.Ingress.TLS }}
+    - hosts:
+      {{- range .Hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .SecretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.Master.Ingress.Hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
 {{- end }}

--- a/stable/jenkins/templates/jenkins-master-networkpolicy.yaml
+++ b/stable/jenkins/templates/jenkins-master-networkpolicy.yaml
@@ -10,7 +10,7 @@ spec:
   ingress:
     # Allow web access to the UI
     - ports:
-      - port: {{ .Values.Master.ContainerPort }}
+      - port: 8080
     # Allow inbound connections from slave
     - from:
       - podSelector:

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -24,7 +24,10 @@ spec:
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
   type: {{.Values.Master.ServiceType}}
   {{if eq .Values.Master.ServiceType "LoadBalancer"}}
-  loadBalancerSourceRanges: {{.Values.Master.LoadBalancerSourceRanges}}
+{{- if .Values.Master.LoadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.Master.LoadBalancerSourceRanges | indent 4 }}
+{{- end }}
   {{if .Values.Master.LoadBalancerIP}}
   loadBalancerIP: {{.Values.Master.LoadBalancerIP}}
   {{end}}

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -16,7 +16,7 @@ spec:
   ports:
     - port: {{.Values.Master.ServicePort}}
       name: http
-      targetPort: {{.Values.Master.ContainerPort}}
+      targetPort: 8080
       {{if (and (eq .Values.Master.ServiceType "NodePort") (not (empty .Values.Master.NodePort)))}}
       nodePort: {{.Values.Master.NodePort}}
       {{end}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -52,7 +52,6 @@ Master:
   # Used to create Ingress record (should used with ServiceType: ClusterIP)
   # HostName: jenkins.cluster.local
   # NodePort: <to set explicitly, choose port between 30000-32767
-  ContainerPort: 8080
   # Enable Kubernetes Liveness and Readiness Probes
   # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
   HealthProbes: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -50,7 +50,6 @@ Master:
   ServiceAnnotations: {}
   #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
   # Used to create Ingress record (should used with ServiceType: ClusterIP)
-  # HostName: jenkins.cluster.local
   # NodePort: <to set explicitly, choose port between 30000-32767
   # Enable Kubernetes Liveness and Readiness Probes
   # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
@@ -116,15 +115,18 @@ Master:
   PodAnnotations: {}
 
   Ingress:
+    Enabled: false
     ApiVersion: extensions/v1beta1
-    Annotations:
+    Annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-
-    TLS:
-    # - secretName: jenkins.cluster.local
-    #   hosts:
-    #     - jenkins.cluster.local
+    Path: /
+    Hosts:
+      - jenkins.cluster.local
+    TLS: []
+    #  - SecretName: jenkins-tls
+    #    Hosts:
+    #      - jenkins.cluster.local
 
 Agent:
   Enabled: true

--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 2.0.2
+version: 2.0.3
 appVersion: 2.2.4
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.2.2
+  version: 4.3.1
 digest: sha256:b75f19f70f8a102eeda32e04c0c99dd8e635de3f3ee27e28c6f93054276e9dc1
-generated: 2018-06-11T12:31:03.893792856+02:00
+generated: 2018-08-01T14:16:06.145545926+02:00

--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.0.2
+
+### Minor Changes
+
+* Fix readinessProbe in daemonset's pod spec
+
 ## v1.0.1
 
 ### Minor Changes

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,5 +1,5 @@
 name: sysdig
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.81.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
           readinessProbe:
             exec:
               command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
-              initialDelaySeconds: 10
+            initialDelaySeconds: 10
           volumeMounts:
             - mountPath: /host/var/run/docker.sock
               name: docker-sock


### PR DESCRIPTION
What this PR does / why we need it: it allows to configure one or several ingress hosts.

Special notes for your reviewer:

/!\ This PR breaks backward compatibility /!\ (Master.Hostname value is removed, replaced by Master.Ingress.Hosts), 
I used a more common ingress template which is regularly found in stable charts. It requires a new helper.