### PR TITLE
[stable/jenkins] Enable multiple ingress hosts for jenkins master

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -54,15 +54,19 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
-| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                                      |
-| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                      |
-| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatibility | `true`                                                                      |
+| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                 |
+| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                |
+| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatibility | `true`                                                               |
 | `Master.CLI`                      | Enable CLI over remoting             | `false`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
 | `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
 | `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
 | `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
+| `Master.Ingress.Enabled`          | Use an Ingress                       | `false`                                                                      |
+| `Master.Ingress.ApiVersion`       | Ingress API version                  | `extensions/v1beta1`                                                         |
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
+| `Master.Ingress.Path`             | Ingress path                         | `/`                                                                          |
+| `Master.Ingress.Hosts`            | Ingress record(s)                    | Not set                                                                      |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -24,6 +24,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jenkins.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "jenkins.kubernetes-version" -}}
   {{- range .Values.Master.InstallPlugins -}}
     {{ if hasPrefix "kubernetes:" . }}

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -1,22 +1,39 @@
-{{- if .Values.Master.HostName }}
+{{- if .Values.Master.Ingress.Enabled -}}
+{{- $fullName := include "jenkins.fullname" . -}}
+{{- $servicePort := .Values.Master.ServicePort -}}
+{{- $ingressPath := .Values.Master.Ingress.Path -}}
 apiVersion: {{ .Values.Master.Ingress.ApiVersion }}
 kind: Ingress
 metadata:
-{{- if .Values.Master.Ingress.Annotations }}
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "jenkins.name" . }}
+    chart: {{ template "jenkins.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.Master.Ingress.Annotations }}
   annotations:
-{{ toYaml .Values.Master.Ingress.Annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
-  name: {{ template "jenkins.fullname" . }}
 spec:
-  rules:
-  - host: {{ .Values.Master.HostName | quote }}
-    http:
-      paths:
-      - backend:
-          serviceName: {{ template "jenkins.fullname" . }}
-          servicePort: {{ .Values.Master.ServicePort }}
 {{- if .Values.Master.Ingress.TLS }}
   tls:
-{{ toYaml .Values.Master.Ingress.TLS | indent 4 }}
-{{- end -}}
+  {{- range .Values.Master.Ingress.TLS }}
+    - hosts:
+      {{- range .Hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .SecretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.Master.Ingress.Hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
 {{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -50,7 +50,6 @@ Master:
   ServiceAnnotations: {}
   #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
   # Used to create Ingress record (should used with ServiceType: ClusterIP)
-  # HostName: jenkins.cluster.local
   # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   # Enable Kubernetes Liveness and Readiness Probes
@@ -130,15 +129,18 @@ Master:
   PodAnnotations: {}
 
   Ingress:
+    Enabled: false
     ApiVersion: extensions/v1beta1
-    Annotations:
+    Annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-
-    TLS:
-    # - secretName: jenkins.cluster.local
-    #   hosts:
-    #     - jenkins.cluster.local
+    Path: /
+    Hosts:
+      - jenkins.cluster.local
+    TLS: []
+    #  - SecretName: jenkins-tls
+    #    Hosts:
+    #      - jenkins.cluster.local
 
 Agent:
   Enabled: true


### PR DESCRIPTION
What this PR does / why we need it: it allows to configure one or several ingress hosts.

Special notes for reviewers:

/!\ This PR breaks backward compatibility /!\ (Master.Hostname value is removed, replaced by Master.Ingress.Hosts),
I used a more common ingress template which is regularly found in stable charts. It requires a new helper.