### PR TITLE
Make nodeport exposure idempotent

### DIFF
--- a/stable/spinnaker/templates/hooks/expose-nodeports.yaml
+++ b/stable/spinnaker/templates/hooks/expose-nodeports.yaml
@@ -31,6 +31,10 @@ spec:
         - -c
         - |
           PATCH='{"spec": {"type":"NodePort"}}'
-          kubectl patch service --namespace {{ .Release.Namespace }} spin-deck --patch "$PATCH"
-          kubectl patch service --namespace {{ .Release.Namespace }} spin-gate --patch "$PATCH"
+          if [ "$(kubectl get service --namespace {{ .Release.Namespace }} spin-deck -o=jsonpath='{.spec.type}')" = "ClusterIP" ]; then
+            kubectl patch service --namespace {{ .Release.Namespace }} spin-deck --patch "$PATCH"
+          fi
+          if [ "$(kubectl get service --namespace {{ .Release.Namespace }} spin-gate -o=jsonpath='{.spec.type}')" = "ClusterIP" ]; then
+            kubectl patch service --namespace {{ .Release.Namespace }} spin-gate --patch "$PATCH"
+          fi
 {{- end }}


### PR DESCRIPTION
The script fails on subsequent runs because `kubectl patch` exits with a non-zero exit code when the patch is a no-op. 

I'm just testing if the service exists as a clusterIP before we apply the patch. There may be a better test to use there but this seems fine for now.